### PR TITLE
fix bug of incorrect film page rendering when film does no exist

### DIFF
--- a/project/src/hooks/api-hooks/use-fetch-film.ts
+++ b/project/src/hooks/api-hooks/use-fetch-film.ts
@@ -13,13 +13,15 @@ export const useFetchFilm = (id: string | undefined) => {
     if (id) {
       setStatus(RequestStatus.Loading);
 
-      const {data} = await api.get<Film>(`${APIRoute.Films}/${id}`);
+      try {
+        const {data} = await api.get<Film>(`${APIRoute.Films}/${id}`);
 
-      if (isAlive.current) {
-        if (data) {
+        if (isAlive.current && data) {
           setFilm(data);
           setStatus(RequestStatus.Success);
-        } else {
+        }
+      } catch(error) {
+        if (isAlive.current){
           setStatus(RequestStatus.Error);
         }
       }

--- a/project/src/pages/film-page/film-page.tsx
+++ b/project/src/pages/film-page/film-page.tsx
@@ -27,14 +27,14 @@ function FilmPage(): JSX.Element {
   const [comments] = useFetchFilmComments(id);
   const [similarFilms] = useFetchSimilarFilms(id);
 
-  if (status === RequestStatus.Loading) {
+  if (!id || status === RequestStatus.Error) {
+    return <PageNotFound />;
+  }
+
+  if (!film || status === RequestStatus.Loading) {
     return (
       <LoadingScreen />
     );
-  }
-
-  if (!film || !id) {
-    return <PageNotFound />;
   }
 
   const handlePlayButtonClick = () => {


### PR DESCRIPTION
Исправил ошибку, при которой лоадер продолжал отображаться, когда было обращение к несуществующей странице.